### PR TITLE
Add HTC ocn

### DIFF
--- a/kernels/ocn/do.bash
+++ b/kernels/ocn/do.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+cd kernel
+ln -s ../../wireguard-linux-compat/src net/wireguard
+
+# Inject the kernel module. Reference: https://git.zx2c4.com/android_kernel_wireguard/tree/patch-kernel.sh
+[[ $(< net/Makefile) == *wireguard* ]] || sed -i "/^obj-\\\$(CONFIG_NETFILTER).*+=/a obj-\$(CONFIG_WIREGUARD) += wireguard/" net/Makefile
+[[ $(< net/Kconfig) == *wireguard* ]] ||  sed -i "/^if INET\$/a source \"net/wireguard/Kconfig\"" net/Kconfig
+
+# Based on Readme.txt in ocndtwl-4.4.153-perf-g0041d80.tar.gz, which is in turn downloaded from htcdev.com
+mkdir out
+make ARCH=arm64 CROSS_COMPILE="$PWD/../aarch64-linux-android-4.9/bin/aarch64-linux-android-" O=out htcperf_defconfig
+make ARCH=arm64 CROSS_COMPILE="$PWD/../aarch64-linux-android-4.9/bin/aarch64-linux-android-" O=out -j$(nproc)
+
+readlink -f out/net/wireguard/wireguard.ko >&7

--- a/kernels/ocn/manifest.xml
+++ b/kernels/ocn/manifest.xml
@@ -1,0 +1,10 @@
+<manifest>
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="github_CaptainThrowback" fetch="https://github.com/CaptainThrowback" />
+
+  <default remote="aosp" sync-j="4" />
+
+  <project path="kernel" name="android_kernel_htc_ocn" remote="github_CaptainThrowback" revision="3.38.1405.1_R5" clone-depth="1" />
+  <!-- use an older version of the toolchain as building this kernel requires GCC, while GCC is absent from the latest version -->
+  <project path="aarch64-linux-android-4.9" name="platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" revision="ndk-r13-release" clone-depth="1" />
+</manifest>

--- a/kernels/ocn/version-hashes.txt
+++ b/kernels/ocn/version-hashes.txt
@@ -1,0 +1,1 @@
+80ee34126cd97c9a15bc3b970a6f38ce30852d0b8547dbcc43eee22956aa1934|Linux version 4.4.153-perf-g66b46bd (and@AABM) (gcc version 4.9.x 20150123 (prerelease) (GCC) ) #1 SMP PREEMPT Thu Nov 7 21:09:01 CST 2019


### PR DESCRIPTION
Apparently, the ocn kernel source tree is created by the same one that
maintains the TWRP image [1]. Only a few irrelevant files are different
from the kernel in the tarball downloaded from htcdev.com
(ocndtwl-4.4.153-perf-g0041d80.tar.gz).

$ diff -ur android_kernel_htc_ocn kernel
Only in android_kernel_htc_ocn: .git
Only in android_kernel_htc_ocn: .gitignore
Only in kernel/Documentation/DocBook/media/dvb: dvbstb.pdf
Only in kernel/Documentation/DocBook/media/v4l: crop.pdf
Only in kernel/Documentation/DocBook/media/v4l: fieldseq_bt.pdf
Only in kernel/Documentation/DocBook/media/v4l: fieldseq_tb.pdf
Only in kernel/Documentation/DocBook/media/v4l: pipeline.pdf
Only in kernel/Documentation/DocBook/media/v4l: vbi_525.pdf
Only in kernel/Documentation/DocBook/media/v4l: vbi_625.pdf
Only in kernel/Documentation/DocBook/media/v4l: vbi_hsync.pdf
Only in android_kernel_htc_ocn: Readme.txt
Only in kernel/arch/sh/boot/compressed: vmlinux.scr
Only in kernel/arch/sh/boot/romimage: vmlinux.scr

I've tested the built module
wireguard-80ee34126cd97c9a15bc3b970a6f38ce30852d0b8547dbcc43eee22956aa1934.ko
on my ocndugl device.

[1] https://twrp.me/htc/htcu11.html

Signed-off-by: Chih-Hsuan Yen <yan12125@gmail.com>