### PR TITLE
Fix building ocn kernel module with GCC>=10 as HOSTCC

### DIFF
--- a/build-one.bash
+++ b/build-one.bash
@@ -4,6 +4,8 @@ set -ex
 [[ $# -eq 1 ]] || { echo "Usage: $0 KERNEL_NAME" >&2; exit 1; }
 BASE="$(readlink -f "$(dirname "$(readlink -f "$0")")")"
 KERNEL_DIR="$BASE/kernels/$1"
+# For use in kernel-specific do.bash files
+export KERNEL_DIR
 [[ -d $KERNEL_DIR ]] || { echo "Error: '$0' does not exist" >&2; exit 1; }
 
 # Step 1) Account for already built modules by hard linking new hashes to the old names.

--- a/kernels/ocn/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch
+++ b/kernels/ocn/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch
@@ -1,0 +1,70 @@
+From ce513359d8507123e63f34b56e67ad558074be22 Mon Sep 17 00:00:00 2001
+From: Dirk Mueller <dmueller@suse.com>
+Date: Tue, 14 Jan 2020 18:53:41 +0100
+Subject: [PATCH] scripts/dtc: Remove redundant YYLOC global declaration
+
+commit e33a814e772cdc36436c8c188d8c42d019fda639 upstream.
+
+gcc 10 will default to -fno-common, which causes this error at link
+time:
+
+  (.text+0x0): multiple definition of `yylloc'; dtc-lexer.lex.o (symbol from plugin):(.text+0x0): first defined here
+
+This is because both dtc-lexer as well as dtc-parser define the same
+global symbol yyloc. Before with -fcommon those were merged into one
+defintion. The proper solution would be to to mark this as "extern",
+however that leads to:
+
+  dtc-lexer.l:26:16: error: redundant redeclaration of 'yylloc' [-Werror=redundant-decls]
+   26 | extern YYLTYPE yylloc;
+      |                ^~~~~~
+In file included from dtc-lexer.l:24:
+dtc-parser.tab.h:127:16: note: previous declaration of 'yylloc' was here
+  127 | extern YYLTYPE yylloc;
+      |                ^~~~~~
+cc1: all warnings being treated as errors
+
+which means the declaration is completely redundant and can just be
+dropped.
+
+Signed-off-by: Dirk Mueller <dmueller@suse.com>
+Signed-off-by: David Gibson <david@gibson.dropbear.id.au>
+[robh: cherry-pick from upstream]
+Cc: stable@vger.kernel.org
+Signed-off-by: Rob Herring <robh@kernel.org>
+[nc: Also apply to dtc-lexer.lex.c_shipped due to a lack of
+     e039139be8c2, where dtc-lexer.l started being used]
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/dtc/dtc-lexer.l             | 1 -
+ scripts/dtc/dtc-lexer.lex.c_shipped | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 0ee1caf03dd0..a9b58b71e25e 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 11cd78e72305..26932b00cf2d 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -637,7 +637,6 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+2.31.1
+

--- a/kernels/ocn/do.bash
+++ b/kernels/ocn/do.bash
@@ -8,6 +8,9 @@ ln -s ../../wireguard-linux-compat/src net/wireguard
 [[ $(< net/Makefile) == *wireguard* ]] || sed -i "/^obj-\\\$(CONFIG_NETFILTER).*+=/a obj-\$(CONFIG_WIREGUARD) += wireguard/" net/Makefile
 [[ $(< net/Kconfig) == *wireguard* ]] ||  sed -i "/^if INET\$/a source \"net/wireguard/Kconfig\"" net/Kconfig
 
+# https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=ce513359d8507123e63f34b56e67ad558074be22
+patch -Np1 -i "$KERNEL_DIR/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch"
+
 # Based on Readme.txt in ocndtwl-4.4.153-perf-g0041d80.tar.gz, which is in turn downloaded from htcdev.com
 mkdir out
 make ARCH=arm64 CROSS_COMPILE="$PWD/../aarch64-linux-android-4.9/bin/aarch64-linux-android-" O=out htcperf_defconfig


### PR DESCRIPTION
I patch kernel sources instead of using compilers provided by Google
(e.g., [1]) as the latter does not look into system headers, and thus
building host tools for the kernel fails with missing OpenSSL headers.

Building the kernel also requires Python 2 on the host, while Python 2
binaries provided by Google (e.g., [2]) are 32-bit ones, and on some
Linux systems, setting up 32-bit libraries is harder than installing
python2 from package managers.

[1] https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.15-4.8/
[2] https://android.googlesource.com/platform/prebuilts/python/linux-x86/2.7.5/

---

I notice the build failure when I was debugging a networking issue and trying to make everything on my phone up-to-date. The issue turned out to be unrelated to WireGuard, while I still feel it better to publish this simple fix.